### PR TITLE
Slightly tweak Mixin target on Fabric

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -8,6 +8,6 @@ yarn_mappings=1.21.1+build.3
 loader_version=0.16.14
 
 # Mod Properties
-mod_version=1.4.0+1.21.1
+mod_version=1.4.1+1.21.1
 maven_group=de.dafuqs
 archives_base_name=arrowhead

--- a/src/main/java/de/dafuqs/arrowhead/mixin/client/AbstractClientPlayerEntityMixinFabric.java
+++ b/src/main/java/de/dafuqs/arrowhead/mixin/client/AbstractClientPlayerEntityMixinFabric.java
@@ -13,8 +13,8 @@ import org.spongepowered.asm.mixin.injection.ModifyArg;
 @Mixin(AbstractClientPlayerEntity.class)
 public abstract class AbstractClientPlayerEntityMixinFabric {
 	
-	@ModifyArg(method = "getFovMultiplier", at = @At(value = "INVOKE", target = "Lnet/minecraft/util/math/MathHelper;lerp(FFF)F"), index = 2)
-	private float arrowhead$applyCustomBowZoom(float delta) {
+	@ModifyArg(method = "Lnet/minecraft/client/network/AbstractClientPlayerEntity;getFovMultiplier()F", at = @At(value = "INVOKE", target = "Lnet/minecraft/util/math/MathHelper;lerp(FFF)F"), index = 2)
+	private float arrowhead$applyCustomBowZoomFabric(float delta) {
 		AbstractClientPlayerEntity thisPlayer = (AbstractClientPlayerEntity)(Object) this;
 		ItemStack itemStack = thisPlayer.getActiveItem();
 		if (thisPlayer.isUsingItem() && itemStack.getItem() instanceof ArrowheadBow arrowheadBow) {

--- a/src/main/java/de/dafuqs/arrowhead/mixin/client/AbstractClientPlayerEntityMixinForge.java
+++ b/src/main/java/de/dafuqs/arrowhead/mixin/client/AbstractClientPlayerEntityMixinForge.java
@@ -14,7 +14,7 @@ import org.spongepowered.asm.mixin.injection.ModifyArg;
 public abstract class AbstractClientPlayerEntityMixinForge {
 	
 	@ModifyArg(method = "getFovMultiplier", at = @At(value = "INVOKE", target = "Lnet/neoforged/neoforge/client/ClientHooks;getFieldOfViewModifier(Lnet/minecraft/world/entity/player/Player;F)F", remap = false), index = 1)
-	private float arrowhead$applyCustomBowZoom(float delta) {
+	private float arrowhead$applyCustomBowZoomForge(float delta) {
 		AbstractClientPlayerEntity thisPlayer = (AbstractClientPlayerEntity)(Object) this;
 		ItemStack itemStack = thisPlayer.getActiveItem();
 		if (thisPlayer.isUsingItem() && itemStack.getItem() instanceof ArrowheadBow arrowheadBow) {


### PR DESCRIPTION
Could be a pure coincidence, but for me Fabric failed to load the refmap from Arrowhead 1.4.0 when bundled as a jar-in-jar. Expanding the method fully seems to have changed how the refmap looks, and now it does find the target reliably.

```diff

"de/dafuqs/arrowhead/mixin/client/AbstractClientPlayerEntityMixinFabric":{
-	"Lnet/minecraft/util/math/MathHelper;lerp(FFF)F":"Lnet/minecraft/class_3532;method_16439(FFF)F",
-	"getFovMultiplier":"Lnet/minecraft/class_742;method_3118()F"
},
"de/dafuqs/arrowhead/mixin/client/AbstractClientPlayerEntityMixinForge":{
"getFovMultiplier":"Lnet/minecraft/class_742;method_3118()F"
},
"de/dafuqs/arrowhead/mixin/client/AbstractClientPlayerEntityMixinFabric":{
+	"Lnet/minecraft/client/network/AbstractClientPlayerEntity;getFovMultiplier()F":"Lnet/minecraft/class_742;method_3118()F",
+	"Lnet/minecraft/util/math/MathHelper;lerp(FFF)F":"Lnet/minecraft/class_3532;method_16439(FFF)F"
},
"de/dafuqs/arrowhead/mixin/client/AbstractClientPlayerEntityMixinForge":{
"getFovMultiplier":"Lnet/minecraft/class_742;method_3118()F"
},
```
